### PR TITLE
Update README with bootRun command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ One Spring bean profile should be activated to choose the database provider that
 The application can be started locally using the following command:
 
 ~~~
-$ ./gradlew tomcatRun -Dspring.profiles.active=<profile>
+$ ./gradlew bootRun -Dspring.profiles.active=<profile>
 ~~~
 
 where `<profile>` is one of the following values:


### PR DESCRIPTION
I was looking at this app this afternoon with a Girls Who Code intern and the getting started command provided wasn't up to date with the latest switch to Spring Boot. Running `./gradlew tomcatRun -Dspring.profiles.active=in-memory` results in error `Task 'tomcatRun' not found in root project 'spring-music'.`