### PR TITLE
H2c support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a sample application for using database services on [Cloud Foundry](http
 
 This application has been built to store the same domain objects in one of a variety of different persistence technologies - relational, document, and key-value stores. This is not meant to represent a realistic use case for these technologies, since you would typically choose the one most applicable to the type of data you need to store, but it is useful for testing and experimenting with different types of services on Cloud Foundry.
 
-The application use Spring Java configuration and [bean profiles](http://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-profiles.html) to configure the application and the connection objects needed to use the persistence stores. It also uses the [Spring Cloud Connectors](http://cloud.spring.io/spring-cloud-connectors/) library to inspect the environment when running on Cloud Foundry. See the [Cloud Foundry documentation](http://docs.cloudfoundry.org/buildpacks/java/spring-service-bindings.html) for details on configuring a Spring application for Cloud Foundry.
+The application use Spring Java configuration and [bean profiles](http://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-profiles.html) to configure the application and the connection objects needed to use the persistence stores. It also uses the [Java CFEnv](https://github.com/pivotal-cf/java-cfenv/) library to inspect the environment when running on Cloud Foundry. See the [Cloud Foundry documentation](http://docs.cloudfoundry.org/buildpacks/java/spring-service-bindings.html) for details on configuring a Spring application for Cloud Foundry.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The application use Spring Java configuration and [bean profiles](http://docs.sp
 
 ## Building
 
-This project requires Java 8 or later to compile.
+This project requires a Java version between 8 and 15 to compile. Java 16 and later versions are not yet supported.
 
 To build a runnable Spring Boot jar file, run the following command: 
 

--- a/src/main/java/org/cloudfoundry/samples/music/config/data/H2cConfig.java
+++ b/src/main/java/org/cloudfoundry/samples/music/config/data/H2cConfig.java
@@ -1,0 +1,15 @@
+package org.cloudfoundry.samples.music.config.data;
+
+import org.apache.coyote.http2.Http2Protocol;
+
+import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class H2cConfig {
+    @Bean
+    public TomcatConnectorCustomizer customizer() {
+      return (connector) -> connector.addUpgradeProtocol(new Http2Protocol());
+    }
+}


### PR DESCRIPTION
Hello!

We are working on implementing HTTP/2 support for app routes on CF. See this [proposal](https://docs.google.com/document/d/1vcqlwchibRPnGn2pPQideaW8rmGMGoHFtgrS4RmsVl8/edit) for more details.

To that end, HTTP/2 apps will need to support H2C, since apps on CF do not terminate their own TLS. We would like to update Spring Music to support H2C for the following reasons:
1. As a development tool while we are building out this feature
2. As an example for Spring developers looking to update their apps to support HTTP/2 on CF

We based this implementation on this Spring Boot issue: https://github.com/spring-projects/spring-boot/issues/21997

Here is the root issue where we are tracking all changes related to this effort: cloudfoundry/routing-release#200

Thanks!